### PR TITLE
Adding compatibility with private feeds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,28 @@ Basic usage
     datetime(2017, 1, 1, 0, 42, 0)
 
 
+Basic usage for private feeds (requiring password)
+-----------
+::
+
+    >>> from spot_sdk import Feed
+    >>> api_key = 'abcdefghijklmnopqrstuvwxy01234567'
+    >>> password = 'your-password'
+    >>> feed = Feed(api_key, password)
+    >>> feed.collect()
+    >>> feed.count()
+    6
+    >>> foo.messages
+    [<spot_sdk.Message object at 0x10fd7f630>, <spot_sdk.Message object at 0x10fd7f6a0>...
+    >>> feed.first().type
+    'UNLIMITED-TRACK'
+    >>> feed.last().battery_state
+    'GOOD'
+    >>> feed.messages[0].latitude
+    42.000
+    >>> feed.last().datetime
+    datetime(2017, 1, 1, 0, 42, 0)
+
 Running Test
 ------------
 ::

--- a/spot_sdk/__init__.py
+++ b/spot_sdk/__init__.py
@@ -50,9 +50,9 @@ class Feed(object):
 
   def __request_url(self):
     if hasattr(self, 'password'):
-      return self.BASE_URL + self.key + '/message.json'
-    else:
       return self.BASE_URL + self.key + '/message.json?feedPassword=' + self.password
+    else:
+      return self.BASE_URL + self.key + '/message.json'
 
   def first(self):
       return self.messages[0]

--- a/spot_sdk/__init__.py
+++ b/spot_sdk/__init__.py
@@ -37,10 +37,22 @@ class Feed(object):
     self.key      = key
     self.messages = []
 
+  def __init__(self, key, password):
+    if not isinstance(key, str):
+      raise SpotSDKError('key should be string')
+    if not isinstance(password, str):
+      raise SpotSDKError('password should be string')
+    self.key      = key
+    self.password = password
+    self.messages = []
+
   BASE_URL = 'https://api.findmespot.com/spot-main-web/consumer/rest-api/2.0/public/feed/'
 
   def __request_url(self):
-    return self.BASE_URL + self.key + '/message.json'
+    if hasattr(self, 'password'):
+      return self.BASE_URL + self.key + '/message.json'
+    else:
+      return self.BASE_URL + self.key + '/message.json?feedPassword=' + password
 
   def first(self):
       return self.messages[0]

--- a/spot_sdk/__init__.py
+++ b/spot_sdk/__init__.py
@@ -52,7 +52,7 @@ class Feed(object):
     if hasattr(self, 'password'):
       return self.BASE_URL + self.key + '/message.json'
     else:
-      return self.BASE_URL + self.key + '/message.json?feedPassword=' + password
+      return self.BASE_URL + self.key + '/message.json?feedPassword=' + self.password
 
   def first(self):
       return self.messages[0]


### PR DESCRIPTION
According to Spot API, a feed password can be provided for those feeds that require so.
[https://www.findmespot.com/en-us/support/spot-gen3/get-help/general/spot-api-support](https://www.findmespot.com/en-us/support/spot-gen3/get-help/general/spot-api-support)
With this pull request I try to achieve compatibility with such feeds without breaking backwards compatibility.

Be advised this is my first pull request ever so please forgive me if it is not up to standards.